### PR TITLE
Update __init__.py

### DIFF
--- a/sqlalchemy_searchable/__init__.py
+++ b/sqlalchemy_searchable/__init__.py
@@ -67,9 +67,8 @@ def search(query, search_query, vector=None, catalog=None):
     if not search_query:
         return query
 
-    entity = query._entities[0].entity_zero.class_
-
-    if not vector:
+    if vector is None:
+        entity = query._entities[0].entity_zero.class_
         search_vectors = inspect_search_vectors(entity)
         vector = search_vectors[0]
 

--- a/tests/test_searchable.py
+++ b/tests/test_searchable.py
@@ -63,6 +63,10 @@ class SearchQueryMixinTestCase(TestCase):
         query = self.TextItemQuery(self.TextItem, self.session)
         query = query.search(u'orrimorri', catalog='finnish')
         assert "to_tsquery(:to_tsquery_1, :to_tsquery_2)" in str(query)
+        
+    def test_search_specific_columns(self):
+        query = self.TextItemQuery(self.TextItem, self.session).with_entities(self.TextItem.id).search("admin")
+        assert query.count() == 1
 
 
 create_test_cases(SearchQueryMixinTestCase)


### PR DESCRIPTION
Fix search() to handle arbitrary queries not returning a whole object (where entity_zero is None). So I can do `search(User.query.columns(User.id), "some search query", User.search_vector)` with this patch applied.