### PR TITLE
New optional `sort` parameter orders results by search rank

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,3 +72,10 @@ After we've created the articles, we can search trhough them.
 
     print query.first().name
     # First article
+
+Optionally specify ``sort=True`` to get results in order of relevance (ts_rank_cd_)::
+
+    query = search(query, 'first', sort=True)
+
+.. _ts_rank_cd: http://www.postgresql.org/docs/devel/static/textsearch-controls.html#TEXTSEARCH-RANKING
+

--- a/sqlalchemy_searchable/__init__.py
+++ b/sqlalchemy_searchable/__init__.py
@@ -56,13 +56,14 @@ def inspect_search_vectors(entity):
     ]
 
 
-def search(query, search_query, vector=None, regconfig=None):
+def search(query, search_query, vector=None, regconfig=None, sort=False):
     """
     Search given query with full text search.
 
     :param search_query: the search query
     :param vector: search vector to use
     :param regconfig: postgresql regconfig to be used
+    :param sort: order results by relevance (quality of hit)
     """
     if not search_query:
         return query
@@ -81,6 +82,11 @@ def search(query, search_query, vector=None, regconfig=None):
         kwargs['postgresql_regconfig'] = regconfig
 
     query = query.filter(vector.match(search_query, **kwargs))
+    if sort:
+        query = query.order_by(sa.desc(sa.func.ts_rank_cd(vector, 
+                                                          sa.func.to_tsquery
+                                                              (search_query))))
+        
     return query.params(term=search_query)
 
 

--- a/tests/test_searchable.py
+++ b/tests/test_searchable.py
@@ -84,7 +84,6 @@ class SearchQueryMixinTestCase(TestCase):
 
     def test_sorted_search_results(self):
         query = self.TextItemQuery(self.TextItem, self.session)
-        import ipdb; ipdb.set_trace()
         unsorted_results = query.search('content some').all()
         sorted_results = query.search('content some', sort=True).all()
         assert sorted(unsorted_results) == sorted(sorted_results)

--- a/tests/test_searchable.py
+++ b/tests/test_searchable.py
@@ -82,6 +82,14 @@ class SearchQueryMixinTestCase(TestCase):
         query = search(self.session.query(self.TextItem.id), 'admin')
         assert query.count() == 1
 
+    def test_sorted_search_results(self):
+        query = self.TextItemQuery(self.TextItem, self.session)
+        import ipdb; ipdb.set_trace()
+        unsorted_results = query.search('content some').all()
+        sorted_results = query.search('content some', sort=True).all()
+        assert sorted(unsorted_results) == sorted(sorted_results)
+        assert sorted_results != unsorted_results
+
 
 create_test_cases(SearchQueryMixinTestCase)
 


### PR DESCRIPTION
I haven't actually been able to run the tests, so help with that would be great.  Otherwise, hopefully this is pretty straightforward.