### PR TITLE
Add support for weighting search terms by column

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -41,6 +41,33 @@ In the following example we use Finnish regconfig instead of the default English
 
         search_vector = TSVectorType('name', regconfig='pg_catalog.finnish')
 
+Weighting search results
+------------------------
+
+PostgreSQL supports `weighting search terms`_ with weights A through D.
+
+In this example, we give higher priority to terms appearing in the article title than in the content.
+::
+
+
+    class Article(Base):
+        __tablename__ = 'article'
+
+        title = sa.Column(sa.Unicode(255))
+        content = sa.Column(sa.UnicodeText)
+
+        search_vector = sa.Column(
+            TSVectorType('title', 'content',
+                         weights={'title': 'A', 'content': 'B'})
+        )
+
+Note that in order to see the effect of this weighting, you must search with ``sort=True``
+
+::
+
+    query = session.query(Article)
+    query = search(query, 'search text', sort=True)
+
 
 Multiple search vectors per class
 ---------------------------------
@@ -144,3 +171,5 @@ This query becomes a little more complex when using left joins. Then you have to
         |
         sa.func.coalesce(Category.search_vector, u'')
     )
+
+.. _weighting search terms: http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-DOCUMENTS

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,8 @@ from sqlalchemy_searchable import (
     vectorizer
 )
 
+CONNECTION_STRING = 'postgres://postgres@localhost/sqlalchemy_searchable_test'
+
 try:
     import __pypy__
 except ImportError:
@@ -36,9 +38,7 @@ class TestCase(object):
     search_trigger_function_name = '{table}_{column}_update'
 
     def setup_method(self, method):
-        self.engine = create_engine(
-            'postgres://postgres@localhost/sqlalchemy_searchable_test'
-        )
+        self.engine = create_engine(CONNECTION_STRING)
         self.engine.execute('CREATE EXTENSION IF NOT EXISTS hstore')
         # self.engine.echo = True
         self.Base = declarative_base()

--- a/tests/test_weighted_search_vector.py
+++ b/tests/test_weighted_search_vector.py
@@ -1,0 +1,60 @@
+import re
+
+import sqlalchemy as sa
+from sqlalchemy_utils import TSVectorType
+
+from sqlalchemy_searchable import search
+from tests import SchemaTestCase, TestCase
+
+
+class WeightedBase(object):
+
+    def create_models(self):
+        class WeightedTextItem(self.Base):
+            __tablename__ = 'textitem'
+
+            id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+
+            name = sa.Column(sa.Unicode(255))
+            content = sa.Column(sa.UnicodeText)
+            search_vector = sa.Column(TSVectorType('name', 'content',
+                                                   weights={'name': 'A',
+                                                            'content': 'B'}))
+        self.WeightedTextItem = WeightedTextItem
+
+
+class TestCreateWeightedSearchVector(WeightedBase, SchemaTestCase):
+    should_create_indexes = [u'ix_textitem_search_vector']
+    should_create_triggers = [u'textitem_search_vector_trigger']
+
+    def test_search_function_weights(self):
+        func_name = 'textitem_search_vector_update'
+        sql = """SELECT proname,prosrc FROM pg_proc
+                 WHERE proname='{name}';"""
+        name, src = self.session.execute(sql.format(name=func_name)).fetchone()
+        pattern = (r"setweight\(to_tsvector\(.+?"
+                   r"coalesce\(NEW.(\w+).+?"
+                   r"\)\), '([A-D])'\)")
+        first, second = (match.groups() for match in re.finditer(pattern, src))
+        assert first == ('name', 'A')
+        assert second == ('content', 'B')
+
+
+class TestWeightedSearchFunction(WeightedBase, TestCase):
+
+    def setup_method(self, method):
+        TestCase.setup_method(self, method)
+        self.session.add(
+            self.WeightedTextItem(name=u'Gort', content=u'Klaatu barada nikto')
+        )
+        self.session.add(
+            self.WeightedTextItem(name=u'Klaatu', content=u'barada nikto')
+        )
+        self.session.commit()
+
+    def test_weighted_search_results(self):
+        query = self.session.query(self.WeightedTextItem)
+        first, second = search(query, 'klaatu', sort=True).all()
+        assert first.search_vector == "'barada':2B 'klaatu':1A 'nikto':3B"
+        assert (second.search_vector ==
+                "'barada':3B 'gort':1A 'klaatu':2B 'nikto':4B")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
 envlist = py26,py27,py33,py34,pypy,pypy3
+
 [testenv]
 deps=
-commands=python setup.py test
+    pytest>=2.2.3
+    pypy,pypy3: psycopg2cffi>=2.6.1
+    py26,py27,py33,py34: psycopg2>=2.4.6
+commands=py.test {posargs}


### PR DESCRIPTION
This changeset adds support for PostgreSQL's `setweight()` function, allowing users to give priority to different search terms depending on which column they appear in.

Note that as a consequence, this now uses the operator `||` to concatenate separate ts_vectors together directly, rather than using the `concat()` function to concatenate the text from several columns together before invoking `to_tsvector()` to convert the result to a TS_VECTOR.

This pull request also includes changes to tox.ini, to make it run the tests. I verified all tests were passing on Python 2.7, 3.3, 3.4 and PyPy. I did *not* test 2.6 or PyPy3.