### PR TITLE
Support unicode letters

### DIFF
--- a/sqlalchemy_searchable/parser.py
+++ b/sqlalchemy_searchable/parser.py
@@ -20,7 +20,7 @@ from validators import email
 
 
 def is_alphanumeric(c):
-    return unicodedata.category(c) in ['Lu', 'Ll', 'Nd']
+    return unicodedata.category(c) in ['Lo', 'Lu', 'Ll', 'Nd']
 
 
 all_unicode = u''.join(six.unichr(c) for c in six.moves.range(65536))


### PR DESCRIPTION
 - Add 'Lo' to alphanumeric categories

Some characters are categorized as 'Lo' by general category in unicode.
For example, Korean character '가' and Japanese character  'は' are categorized as 'Lo'.

It also fix #50.

P.S. 'Lo' means just Letter: http://www.unicode.org/reports/tr44/#General_Category_Values