### PR TITLE
Eliminate manipulation of __table_args__

### DIFF
--- a/sqlalchemy_searchable/__init__.py
+++ b/sqlalchemy_searchable/__init__.py
@@ -312,14 +312,10 @@ class SearchManager():
         ]
 
     def append_index(self, cls, column):
-        if not hasattr(cls, '__table_args__') or cls.__table_args__ is None:
-            cls.__table_args__ = []
-        cls.__table_args__ = list(cls.__table_args__).append(
-            sa.Index(
-                '_'.join(('ix', column.table.name, column.name)),
-                column,
-                postgresql_using='gin'
-            )
+        sa.Index(
+            '_'.join(('ix', column.table.name, column.name)),
+            column,
+            postgresql_using='gin'
         )
 
     def process_mapper(self, mapper, cls):


### PR DESCRIPTION
Just by creating an `Index`, it's automatically added to its column's table's `indexes` list. There's no need to mess with `__table_args__`, and in fact it breaks classes which implement a `@declared_attr` `__table_args__`. This patch removes the `__table_args__` manipulation in `append_index`, leaving only the Index creation.