### PR TITLE
fix code snippet configuration.rst

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -112,7 +112,7 @@ Consider the following model definition. Here each article has one author.
 
 
     class Category(Base):
-        __tablename__ = 'article'
+        __tablename__ = 'category'
 
         id = sa.Column(sa.Integer, primary_key=True)
         name = sa.Column(sa.Unicode(255))


### PR DESCRIPTION
Current code snipet raises: 
```InvalidRequestError: Table 'article' is already defined for this MetaData instance.  Specify 'extend_existing=True' to redefine options and columns on an existing Table object.```