### PR TITLE
Fix for sqlalchemy 1.4 AttributeError: 'Query' object has no attribute '_entities' 

### DIFF
--- a/sqlalchemy_searchable/__init__.py
+++ b/sqlalchemy_searchable/__init__.py
@@ -56,7 +56,7 @@ def search(query, search_query, vector=None, regconfig=None, sort=False):
         return query
 
     if vector is None:
-        entity = query._entities[0].entity_zero.class_
+        entity = query.column_descriptions[0]["entity"]
         search_vectors = inspect_search_vectors(entity)
         vector = search_vectors[0]
 


### PR DESCRIPTION
Query does not have `_entities` attribute anymore, so we can get `entity` in `column_description` instead.