### PR TITLE
Fix required SQLAlchemy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'SQLAlchemy>=0.9.0',
+        'SQLAlchemy>=1.3.0',
         'SQLAlchemy-Utils>=0.29.0',
         'validators>=0.3.0',
     ],


### PR DESCRIPTION
The tests fail on SQLAlchemy <1.3.0 with the following error:

    tests/__init__.py:10: in <module>
        from sqlalchemy.orm.session import close_all_sessions
    E   ImportError: cannot import name 'close_all_sessions'

[`close_all_sessions`][1] function was added in SQLAlchemy 1.3.

[1]: https://docs.sqlalchemy.org/en/14/orm/session_api.html?highlight=close_all_sessions#sqlalchemy.orm.close_all_sessions