### PR TITLE
Use Tox for running the tests and linting in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,18 @@ before_script:
   - psql -c 'create database sqlalchemy_searchable_test;' -U postgres
 
 language: python
-python:
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7
-  - pypy3
+env:
+  - TOXENV=py-sqla{1.3}
+matrix:
+  include:
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+    - python: pypy3
+    - python: 3.7
+      env: TOXENV=lint
 install:
-  - pip install -e ".[test]"
+  - pip install tox
 script:
-  - isort --recursive --diff sqlalchemy_searchable tests && isort --recursive --check-only sqlalchemy_searchable tests
-  - flake8 sqlalchemy_searchable tests
-  - py.test
+  - tox

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,8 @@ Provides fulltext search capabilities for declarative SQLAlchemy models.
 
 import os
 import re
+
 from setuptools import setup
-
-try:
-    import __pypy__
-except ImportError:
-    __pypy__ = None
-
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -25,15 +20,6 @@ def get_version():
     pattern = r"^__version__ = '(.*?)'$"
     return re.search(pattern, contents, re.MULTILINE).group(1)
 
-
-extras_require = {
-    'test': [
-        'pytest>=2.2.3',
-        'psycopg2cffi>=2.6.1' if __pypy__ else 'psycopg2>=2.4.6',
-        'flake8>=2.4.0',
-        'isort>=3.9.6'
-    ],
-}
 
 setup(
     name='SQLAlchemy-Searchable',
@@ -56,7 +42,6 @@ setup(
         'SQLAlchemy-Utils>=0.29.0',
         'validators>=0.3.0',
     ],
-    extras_require=extras_require,
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps=
     pytest>=2.2.3
     psycopg2cffi>=2.6.1; platform_python_implementation == 'PyPy'
     psycopg2>=2.4.6; platform_python_implementation == 'CPython'
+    typing; python_version == '3.4'
     sqla1.3: SQLAlchemy>=1.3,<1.4
     lint: flake8
     lint: isort

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py34,py35,py36,py37,pypy3
+envlist = {py34,py35,py36,py37,pypy3}-sqla{1.3}
 
 [testenv]
 deps=
     pytest>=2.2.3
     pypy3: psycopg2cffi>=2.6.1
     py34,py35,py36,py37: psycopg2>=2.4.6
+    sqla1.3: SQLAlchemy>=1.3,<1.4
 commands=py.test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = {py34,py35,py36,py37,pypy3}-sqla{1.3}, lint
 
 [testenv]
 deps=
+    attrs==20.3.0; python_version == '3.4'
     pytest>=2.2.3
     psycopg2cffi>=2.6.1; platform_python_implementation == 'PyPy'
     psycopg2>=2.4.6; platform_python_implementation == 'CPython'

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,17 @@
 [tox]
-envlist = {py34,py35,py36,py37,pypy3}-sqla{1.3}
+envlist = {py34,py35,py36,py37,pypy3}-sqla{1.3}, lint
 
 [testenv]
 deps=
     pytest>=2.2.3
-    pypy3: psycopg2cffi>=2.6.1
-    py34,py35,py36,py37: psycopg2>=2.4.6
+    psycopg2cffi>=2.6.1; platform_python_implementation == 'PyPy'
+    psycopg2>=2.4.6; platform_python_implementation == 'CPython'
     sqla1.3: SQLAlchemy>=1.3,<1.4
+    lint: flake8
+    lint: isort
 commands=py.test {posargs}
+
+[testenv:lint]
+commands =
+    isort --recursive --check-only --diff sqlalchemy_searchable tests
+    flake8 sqlalchemy_searchable tests


### PR DESCRIPTION
This fixes the CI build which is currently broken for many reasons.

* **Restrict SQLAlchemy version in Tox envs**

  Restrict the SQLAlchemy version to `>=1.3,<1.4` when running the tests with Tox. This also prepares the Tox configuration so that it is easy to add SQLAlchemy 1.4 to the test matrix once SQLAlchemy-Searchable supports it (#100).

* **Use Tox for running the tests and linting in CI**

  This makes the tests pass in CI because for some Python versions SQLAlchemy 1.4 got installed which SQLAlchemy-Searchable does not yet support. This also makes the CI environment more consistent with how the tests are run locally and it will make it simple add SQLAlchemy 1.4 to the CI test matrix once SQLAlchemy-Seachable supports it.

* **Pin `attrs` for Python 3.4**

  `attrs` dropped Python 3.4 support in 21.1.0. In 21.2.0, `attrs` was declared imcompatible with Python 3.4 and 21.1.0 was later yanked from PyPi. The last `pip` version compatible with Python 3.4 ignores the yank, so it tries to install the broken 21.1.0 version anyway. Therefore, `attrs` must be pinned to the last compatible version with Python 3.4. See also https://github.com/python-attrs/attrs/pull/807.

* **Install `typing` package for Python 3.4 in tests**
 
  This fixes tests crashing in Python 3.4 to the following error:

      ImportError: No module named 'typing'

  `typing` package backports the standard library `typing` module to Python versions older than 3.5. Alternatively, we can wait for the next 1.3 patch release, [1.3.25](https://docs.sqlalchemy.org/en/14/changelog/changelog_13.html#change-1.3.25), which will include a fix for this error.