### PR TITLE
feat!: drop python 3.6 and 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,6 @@ jobs:
           - name: "Python 3.8"
             python: "3.8"
 
-          - name: "Python 3.7"
-            python: "3.7"
-
           - name: "PyPy"
             python: "pypy3.9"
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Changelog
 
 Here you can see the full list of changes between each SQLAlchemy-Searchable release.
 
+Unreleased
+^^^^^^^^^^
+
+- **BREAKING CHANGE**: Drop support for Python 3.6 and 3.7
 
 1.4.1 (2021-06-15)
 ^^^^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Installation
     pip install SQLAlchemy-Searchable
 
 
-Supported versions are python 2.7 and 3.3+.
+Supported versions are Python 3.8 and newer.
 
 
 QuickStart

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=[
         'SQLAlchemy>=1.3.0',
         'SQLAlchemy-Utils>=0.37.5',
@@ -50,8 +50,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,pypy3}-sqla{1.3,1.4}, lint
+envlist = {py38,py39,pypy3}-sqla{1.3,1.4}, lint
 
 [testenv]
 deps=


### PR DESCRIPTION
Drop support for Python 3.6 and 3.7, which have reached the end of their lives. See https://endoflife.date/python.