### PR TITLE
feat!: drop sqlalchemy 1.3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,5 @@ jobs:
       - name: Run tests
         env:
           SQLALCHEMY_SEARCHABLE_TEST_PASSWORD: postgres
-          TOXENV: py-sqla1.3, py-sqla1.4
+          TOXENV: py-sqla1.4
         run: tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ^^^^^^^^^^
 
 - **BREAKING CHANGE**: Drop support for Python 3.6 and 3.7
+- **BREAKING CHANGE**: Drop support for SQLAlchemy 1.3
 
 1.4.1 (2021-06-15)
 ^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     platforms='any',
     python_requires='>=3.8',
     install_requires=[
-        'SQLAlchemy>=1.3.0',
+        'SQLAlchemy>=1.4,<1.5',
         'SQLAlchemy-Utils>=0.37.5',
         'validators>=0.3.0',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = {py38,py39,pypy3}-sqla{1.3,1.4}, lint
+envlist = {py38,py39,pypy3}-sqla{1.4}, lint
 
 [testenv]
 deps=
     pytest>=2.2.3
     psycopg2cffi>=2.6.1; platform_python_implementation == 'PyPy'
     psycopg2>=2.4.6; platform_python_implementation == 'CPython'
-    sqla1.3: SQLAlchemy>=1.3,<1.4
     sqla1.4: SQLAlchemy>=1.4,<1.5
     lint: flake8
     lint: isort>=4.0,<5.0


### PR DESCRIPTION
Drop support for SQLAlchemy 1.3 which is no longer maintained. See https://www.sqlalchemy.org/download.html#versions