### PR TITLE
build: remove validators dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 
 - **BREAKING CHANGE**: Drop support for Python 3.6 and 3.7
 - **BREAKING CHANGE**: Drop support for SQLAlchemy 1.3
+- Remove ``validators`` dependency
 
 1.4.1 (2021-06-15)
 ^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     install_requires=[
         'SQLAlchemy>=1.4,<1.5',
         'SQLAlchemy-Utils>=0.37.5',
-        'validators>=0.3.0',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
`validators` package was not used anywhere. Remove the dependency.