### PR TITLE
build: use ruff for linting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,13 +11,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
-from sqlalchemy_searchable import __version__
+from sqlalchemy_searchable import __version__  # noqa: E402
 
 # -- General configuration -----------------------------------------------------
 
@@ -26,7 +27,15 @@ from sqlalchemy_searchable import __version__
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.viewcode'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,9 @@ exclude = [
     "/docs/_build",
 ]
 
-[tool.isort]
-known_first_party = ["sqlalchemy_searchable", "tests"]
-line_length       = 79
-multi_line_output = 3
-order_by_type     = false
+[tool.ruff]
+select = ["E", "F", "I"]
+
+[tool.ruff.isort]
+known-first-party = ["sqlalchemy_searchable", "tests"]
+order-by-type     = false

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ from sqlalchemy_searchable import (
     remove_listeners,
     search_manager,
     SearchQueryMixin,
-    vectorizer
+    vectorizer,
 )
 
 DB_USER = os.environ.get('SQLALCHEMY_SEARCHABLE_TEST_USER', 'postgres')

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,6 @@ deps=
     psycopg2cffi>=2.6.1; platform_python_implementation == 'PyPy'
     psycopg2>=2.4.6; platform_python_implementation == 'CPython'
     sqla1.4: SQLAlchemy>=1.4,<1.5
-    lint: flake8
-    lint: isort>=5.0,<6.0
 passenv =
     SQLALCHEMY_SEARCHABLE_TEST_USER
     SQLALCHEMY_SEARCHABLE_TEST_PASSWORD
@@ -16,6 +14,5 @@ passenv =
 commands=py.test {posargs}
 
 [testenv:lint]
-commands =
-    isort --check-only --diff sqlalchemy_searchable tests
-    flake8 sqlalchemy_searchable tests
+deps = ruff
+commands = ruff check .


### PR DESCRIPTION
Use [Ruff][1] for linting. This replaces both isort and flake8.

[1]: https://beta.ruff.rs/docs/