### PR TITLE
test: turn on sqlalchemy 2 deprecation warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ passenv =
     SQLALCHEMY_SEARCHABLE_TEST_USER
     SQLALCHEMY_SEARCHABLE_TEST_PASSWORD
     SQLALCHEMY_SEARCHABLE_TEST_DB
+setenv =
+    SQLALCHEMY_WARN_20=1
 commands=py.test {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
Set environment variable `SQLALCHEMY_WARN_20=1` to show all SQLAlchemy 2.0 deprecation warnings when running the tests with tox.

Refs #111