### PR TITLE
feat: add support for sqlalchemy 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,5 +57,5 @@ jobs:
       - name: Run tests
         env:
           SQLALCHEMY_SEARCHABLE_TEST_PASSWORD: postgres
-          TOXENV: py-sqla1.4
+          TOXENV: py-sqla1.4, py-sqla2.0
         run: tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
 - Remove ``validators`` dependency
 - Add support for Python 3.10 and 3.11
 - Use the ``pyproject.toml`` standard to specify project metadata, dependencies and tool configuration. Use Hatch to build the project.
+- Add support for SQLAlchemy 2.0
 
 1.4.1 (2021-06-15)
 ^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "SQLAlchemy-Utils>=0.37.5",
-    "SQLAlchemy>=1.4,<1.5",
+    "SQLAlchemy>=1.4",
 ]
 
 [project.urls]
@@ -48,11 +48,6 @@ include = [
 ]
 exclude = [
     "/docs/_build",
-]
-
-[tool.pytest.ini_options]
-filterwarnings = [
-    "error::sqlalchemy.exc.RemovedIn20Warning",
 ]
 
 [tool.ruff]

--- a/sqlalchemy_searchable/__init__.py
+++ b/sqlalchemy_searchable/__init__.py
@@ -119,7 +119,7 @@ class SQLConstruct:
         else:
             value = vectorizer_func(value)
         value = sa.func.coalesce(value, sa.text("''"))
-        value = sa.func.to_tsvector(self.options["regconfig"], value)
+        value = sa.func.to_tsvector(sa.literal(self.options["regconfig"]), value)
         if column.name in self.options["weights"]:
             weight = self.options["weights"][column.name]
             value = sa.func.setweight(value, weight)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py38,py39,310,311,pypy3}-sqla{1.4}, lint
+envlist = {py38,py39,310,311,pypy3}-sqla{1.4,2.0}, lint
 
 [testenv]
 deps=
@@ -7,6 +7,7 @@ deps=
     psycopg2cffi>=2.6.1; platform_python_implementation == 'PyPy'
     psycopg2>=2.4.6; platform_python_implementation == 'CPython'
     sqla1.4: SQLAlchemy>=1.4,<1.5
+    sqla2.0: SQLAlchemy>=2.0,<2.1
 passenv =
     SQLALCHEMY_SEARCHABLE_TEST_USER
     SQLALCHEMY_SEARCHABLE_TEST_PASSWORD


### PR DESCRIPTION
Test against SQLAlchemy 2.0 and update the SQLAlchemy dependency to remove the `<1.5` version restriction.

Closes #111. Closes #109.