### PR TITLE
test: fix 'parse_websearch' tests on PostgreSQL 14 and later 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   tests:
-    name: ${{ matrix.name }}
+    name: Python ${{ matrix.python }} + PostgreSQL ${{ matrix.postgresql }}
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:12
+        image: postgres:${{ matrix.postgresql }}
         env:
           POSTGRES_DB: sqlalchemy_searchable_test
           POSTGRES_USER: postgres
@@ -27,20 +27,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Python 3.11"
-            python: "3.11"
+          - python: "3.11"
+            postgresql: "15"
 
-          - name: "Python 3.10"
-            python: "3.10"
+          - python: "3.10"
+            postgresql: "14"
 
-          - name: "Python 3.9"
-            python: "3.9"
+          - python: "3.9"
+            postgresql: "13"
 
-          - name: "Python 3.8"
-            python: "3.8"
+          - python: "3.8"
+            postgresql: "12"
 
-          - name: "PyPy"
-            python: "pypy3.9"
+          - python: "pypy3.9"
+            postgresql: "11"
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
 - Use the ``pyproject.toml`` standard to specify project metadata, dependencies and tool configuration. Use Hatch to build the project.
 - Add support for SQLAlchemy 2.0
 - Rewrite the test suite to use pytest fixtures ove classic xunit-style set-up
+- Fix ``parse_websearch`` tests on PostgreSQL 14 and later
 
 1.4.1 (2021-06-15)
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Unreleased
 - Add support for SQLAlchemy 2.0
 - Rewrite the test suite to use pytest fixtures ove classic xunit-style set-up
 - Fix ``parse_websearch`` tests on PostgreSQL 14 and later
+- Add PostgreSQL versions 11, 13, 14 and 15 to the CI build matrix. Previously, the tests were only run on PostgreSQL 12.
 
 1.4.1 (2021-06-15)
 ^^^^^^^^^^^^^^^^^^

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,19 @@ if __pypy__:
     compat.register()
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "postgresql_min_version(min_version): "
+        "skip the test if PostgreSQL version is less than min_version",
+    )
+    config.addinivalue_line(
+        "markers",
+        "postgresql_max_version(max_version): "
+        "skip the test if PostgreSQL version is greater than max_version",
+    )
+
+
 @pytest.fixture
 def engine():
     db_user = os.environ.get("SQLALCHEMY_SEARCHABLE_TEST_USER", "postgres")
@@ -54,6 +67,35 @@ def engine():
 
     yield engine
     engine.dispose()
+
+
+@pytest.fixture
+def postgresql_version(engine):
+    with engine.connect():
+        major, _ = engine.dialect.server_version_info
+        return major
+
+
+@pytest.fixture(autouse=True)
+def check_postgresql_min_version(request, postgresql_version):
+    postgresql_min_version_mark = request.node.get_closest_marker(
+        "postgresql_min_version"
+    )
+    if postgresql_min_version_mark:
+        min_version = postgresql_min_version_mark.args[0]
+        if postgresql_version < min_version:
+            pytest.skip(f"Requires PostgreSQL >= {min_version}")
+
+
+@pytest.fixture(autouse=True)
+def check_postgresql_max_version(request, postgresql_version):
+    postgresql_max_version_mark = request.node.get_closest_marker(
+        "postgresql_max_version"
+    )
+    if postgresql_max_version_mark:
+        max_version = postgresql_max_version_mark.args[0]
+        if postgresql_version > max_version:
+            pytest.skip(f"Requires PostgreSQL <= {max_version}")
 
 
 @pytest.fixture

--- a/tests/test_sql_functions.py
+++ b/tests/test_sql_functions.py
@@ -32,8 +32,26 @@ class TestParse:
             ('"star or or wars"', "star:* <-> or:* <-> or:* <-> wars:*"),
             ("star or   or    or    wars", "'star':* | 'or':* | 'wars':*"),
             ("star oror wars", "'star':* & 'oror':* & 'wars':*"),
-            ("star-wars", "'star-wars':* & 'star':* & 'wars':*"),
-            ("star----wars", "'star':* & 'wars':*"),
+            pytest.param(
+                "star-wars",
+                "'star-wars':* & 'star':* & 'wars':*",
+                marks=pytest.mark.postgresql_max_version(13),
+            ),
+            pytest.param(
+                "star-wars",
+                "'star-wars':* <-> 'star':* <-> 'wars':*",
+                marks=pytest.mark.postgresql_min_version(14),
+            ),
+            pytest.param(
+                "star----wars",
+                "'star':* & 'wars':*",
+                marks=pytest.mark.postgresql_max_version(13),
+            ),
+            pytest.param(
+                "star----wars",
+                "'star':* <-> 'wars':*",
+                marks=pytest.mark.postgresql_min_version(14),
+            ),
             ("star   wars    luke", "'star':* & 'wars':* & 'luke':*"),
             ("örrimöykky", "'örrimöykky':*"),
             ("-star", "!'star':*"),
@@ -72,14 +90,35 @@ class TestParse:
                 "'star':* <-> 'wars':* & 'death':* <-> 'star':*",
             ),
             ("star or wars luke or solo", "'star':* | 'wars':* & 'luke':* | 'solo':*"),
-            ("-star#wars", "!( 'star':* & 'wars':* )"),
-            (
+            pytest.param(
+                "-star#wars",
+                "!( 'star':* & 'wars':* )",
+                marks=pytest.mark.postgresql_max_version(13),
+            ),
+            pytest.param(
+                "-star#wars",
+                "!( 'star':* <-> 'wars':* )",
+                marks=pytest.mark.postgresql_min_version(14),
+            ),
+            pytest.param(
                 "-star#wars or -star#wars",
                 "!( 'star':* & 'wars':* ) | !( 'star':* & 'wars':* )",
+                marks=pytest.mark.postgresql_max_version(13),
             ),
-            (
+            pytest.param(
+                "-star#wars or -star#wars",
+                "!( 'star':* <-> 'wars':* ) | !( 'star':* <-> 'wars':* )",
+                marks=pytest.mark.postgresql_min_version(14),
+            ),
+            pytest.param(
                 '"star#wars star_wars"',
                 "( 'star':* & 'wars':* ) <-> ( 'star':* & 'wars':* )",
+                marks=pytest.mark.postgresql_max_version(13),
+            ),
+            pytest.param(
+                '"star#wars star_wars"',
+                "'star':* <-> 'wars':* <-> 'star':* <-> 'wars':*",
+                marks=pytest.mark.postgresql_min_version(14),
             ),
         ),
     )


### PR DESCRIPTION
In PostgreSQL 14, [`websearch_to_tsquery()` has been fixed to properly parse query text containing discarded tokens][1]. This affected the tests for `parse_websearch()` which is using `websearch_to_tsquery()` under the hood. Also, add PostgreSQL versions 11, 13, 14 and 15 to the build matrix. Previously, the tests were only run on PostgreSQL 12.

[1]: https://www.postgresql.org/docs/14/release-14.html

