### PR TITLE
docs: improve vectorizer documentation

### DIFF
--- a/docs/vectorizers.rst
+++ b/docs/vectorizers.rst
@@ -1,11 +1,103 @@
 Vectorizers
 ===========
 
-.. automodule:: sqlalchemy_searchable.vectorizers
+Vectorizers provide means for turning various column types and columns into fulltext
+search vector. While PostgreSQL inherently knows how to vectorize string columns,
+situations arise where additional vectorization rules are neede. This section outlines
+the process of creating and utilizing vectorization rules for both specific column
+instances and column types.
+
+Type vectorizers
+----------------
+
+By default, PostgreSQL can only directly vectorize string columns. However, scenarios
+may arise where vectorizing non-string columns becomes essential. For instance, when
+dealing with an :class:`~sqlalchemy.dialects.postgresql.HSTORE` column within your model
+that requires fulltext indexing, a dedicated vectorization rule must be defined.
+
+To establish a vectorization rule, use the :data:`~sqlalchemy_searchable.vectorizer`
+decorator. The subsequent example demonstrates how to apply a vectorization rule to the
+values within all :class:`~sqlalchemy.dialects.postgresql.HSTORE`-typed columns present
+in your models::
+
+    from sqlalchemy import cast, func, Text
+    from sqlalchemy.dialects.postgresql import HSTORE
+    from sqlalchemy_searchable import vectorizer
+
+
+    @vectorizer(HSTORE)
+    def hstore_vectorizer(column):
+        return cast(func.avals(column), Text)
+
+The expression returned by the vectorizer is then employed for all fulltext indexed
+columns of type :class:`~sqlalchemy.dialects.postgresql.HSTORE`. Consider the following
+model as an illustration::
+
+    from sqlalchemy import Column, Integer
+    from sqlalchemy_utils import TSVectorType
+
+
+    class Article(Base):
+        __tablename__ = 'article'
+
+        id = Column(Integer, primary_key=True, autoincrement=True)
+        name_translations = Column(HSTORE)
+        content_translations = Column(HSTORE)
+        search_vector = Column(
+            TSVectorType(
+                "name_translations",
+                "content_translations",
+            )
+        )
+
+In this scenario, SQLAlchemy-Searchable would create the following search trigger for
+the model using the default configuration:
+
+.. code-block:: postgres
+
+        CREATE FUNCTION
+            article_search_vector_update() RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.search_vector = to_tsvector(
+                'pg_catalog.english',
+                coalesce(CAST(avals(NEW.name_translations) AS TEXT), '')
+            ) || to_tsvector(
+                'pg_catalog.english',
+                coalesce(CAST(avals(NEW.content_translations) AS TEXT), '')
+            );
+            RETURN NEW;
+        END
+        $$ LANGUAGE 'plpgsql';
+
+
+Column vectorizers
+------------------
+
+Sometimes you may want to set special vectorizer only for specific column. This
+can be achieved as follows::
+
+    class Article(Base):
+        __tablename__ = "article"
+
+        id = Column(Integer, primary_key=True, autoincrement=True)
+        name_translations = Column(HSTORE)
+        search_vector = Column(TSVectorType("name_translations"))
+
+
+    @vectorizer(Article.name_translations)
+    def name_vectorizer(column):
+        return cast(func.avals(column), Text)
+
+
+.. note::
+
+    Column vectorizers always have precedence over type vectorizers.
 
 API
 ^^^
 
+.. currentmodule:: sqlalchemy_searchable
+.. autodata:: vectorizer
 .. autoclass:: Vectorizer
-    :members:
-
+   :members:
+   :special-members: __call__

--- a/sqlalchemy_searchable/__init__.py
+++ b/sqlalchemy_searchable/__init__.py
@@ -14,6 +14,10 @@ __version__ = "1.4.1"
 
 
 vectorizer = Vectorizer()
+"""
+An instance of :class:`Vectorizer` that keeps a track of the registered vectorizers. Use
+this as a decorator to register a function as a vectorizer.
+"""
 
 
 class SearchQueryMixin:

--- a/sqlalchemy_searchable/vectorizers.py
+++ b/sqlalchemy_searchable/vectorizers.py
@@ -1,99 +1,3 @@
-"""
-Vectorizers provide means for changing the way how different column types and
-columns are turned into fulltext search vectors.
-
-Type vectorizers
-----------------
-
-By default PostgreSQL only knows how to vectorize string columns. If your model
-contains for example HSTORE column which you would like to fulltext index you
-need to define special vectorization rule for this.
-
-The easiest way to add a vectorization rule is by using the vectorizer
-decorator. In the following example we vectorize only the values of all HSTORE
-typed columns are models may have.
-
-::
-
-    import sqlalchemy as sa
-    from sqlalchemy.dialects.postgresql import HSTORE
-    from sqlalchemy_searchable import vectorizer
-
-
-    @vectorizer(HSTORE)
-    def hstore_vectorizer(column):
-        return sa.cast(sa.func.avals(column), sa.Text)
-
-
-The SQLAlchemy clause construct returned by the vectorizer will be used for all
-fulltext indexed columns that are of type HSTORE. Consider the following
-model::
-
-
-    class Article(Base):
-        __tablename__ = 'article'
-
-        id = sa.Column(sa.Integer)
-        name_translations = sa.Column(HSTORE)
-        content_translations = sa.Column(HSTORE)
-
-
-Now SQLAlchemy-Searchable would create the following search trigger for this
-model (with default configuration)
-
-.. code-block:: postgres
-
-    CREATE FUNCTION
-        textitem_search_vector_update() RETURNS TRIGGER AS $$
-    BEGIN
-        NEW.search_vector = to_tsvector(
-            'simple',
-            concat(
-                regexp_replace(
-                    coalesce(
-                        CAST(avals(NEW.name_translations) AS TEXT),
-                        ''
-                    ),
-                    '[-@.]', ' ', 'g'
-                ),
-                ' ',
-                regexp_replace(
-                    coalesce(
-                        CAST(avals(NEW.content_translations) AS TEXT),
-                        ''
-                    ),
-                    '[-@.]', ' ', 'g'),
-                    ' '
-                )
-            );
-        RETURN NEW;
-    END
-    $$ LANGUAGE 'plpgsql';
-
-
-Column vectorizers
-------------------
-
-Sometimes you may want to set special vectorizer only for specific column. This
-can be achieved as follows::
-
-
-    class Article(Base):
-        __tablename__ = 'article'
-
-        id = sa.Column(sa.Integer)
-        name_translations = sa.Column(HSTORE)
-
-
-    @vectorizer(Article.name_translations)
-    def name_vectorizer(column):
-        return sa.cast(sa.func.avals(column), sa.Text)
-
-
-.. note::
-
-    Column vectorizers always have precedence over type vectorizers.
-"""
 from functools import wraps
 from inspect import isclass
 
@@ -110,6 +14,7 @@ class Vectorizer:
         )
 
     def clear(self):
+        """Clear all registered vectorizers."""
         self.type_vectorizers = {}
         self.column_vectorizers = {}
 
@@ -138,21 +43,10 @@ class Vectorizer:
         raise KeyError(column)
 
     def __call__(self, type_or_column):
-        """
-        Decorator that marks given function as vectorizer for given column or
-        type.
+        """Decorator to register a function as a vectorizer.
 
-        In the following example we add vectorizer for HSTORE type.
-
-        ::
-
-            from sqlalchemy.dialects.postgresql import HSTORE
-
-
-            @vectorizer(HSTORE)
-            def hstore_vectorizer(column):
-                return sa.func.avals(column)
-
+        :param type_or_column: the SQLAlchemy database data type or the column to
+            register a vectorizer for
         """
 
         def outer(func):


### PR DESCRIPTION
Rewrite the vectorizer documentation:

- Ensure the code examples are up-to-date and working
- Move the documentation from the module docstring to `docs/vectorizers.rst` to be consistent with other documentation.
- Fix grammar and formatting issues
- Add the `vectorizer` object and the `clear` method to the API section.