### PR TITLE
docs: improve Flask-SQLAlchemy integration documentation

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -1,42 +1,46 @@
 Flask-SQLAlchemy integration
 ----------------------------
 
-SQLAlchemy-Searchable can be neatly integrated into Flask-SQLAlchemy using SearchQueryMixin class.
+.. warning::
+    The query interface is considered legacy in SQLAlchemy. Prefer using
+    ``session.execute(search(...))`` instead.
 
+SQLAlchemy-Searchable can be integrated into Flask-SQLAlchemy using
+``SearchQueryMixin`` class::
 
-Example ::
-
-    from flask.ext.sqlalchemy import SQLAlchemy, BaseQuery
-    from sqlalchemy_searchable import SearchQueryMixin
+    from flask import Flask
+    from flask_sqlalchemy import SQLAlchemy
+    from flask_sqlalchemy.query import Query
     from sqlalchemy_utils.types import TSVectorType
-    from sqlalchemy_searchable import make_searchable
+    from sqlalchemy_searchable import SearchQueryMixin, make_searchable
 
-    db = SQLAlchemy()
+    app = Flask(__name__)
+    db = SQLAlchemy(app)
 
     make_searchable(db.metadata)
-    
 
-    class ArticleQuery(BaseQuery, SearchQueryMixin):
+
+    class ArticleQuery(Query, SearchQueryMixin):
         pass
 
 
     class Article(db.Model):
         query_class = ArticleQuery
-        __tablename__ = 'article'
+        __tablename__ = "article"
 
         id = db.Column(db.Integer, primary_key=True)
-        name = db.Column(db.Unicode(255))
-        content = db.Column(db.UnicodeText)
-        search_vector = db.Column(TSVectorType('name', 'content'))
-    
-    db.configure_mappers() #very important!
-    db.create_all()
+        name = db.Column(db.String(255))
+        content = db.Column(db.Text)
+        search_vector = db.Column(TSVectorType("name", "content"))
 
 
-Now this is where the fun begins! SearchQueryMixin provides a search method for ArticleQuery. You can chain calls just like when using query filter calls.
-Here we search for first 5 articles that contain the word 'Finland'.
-::
+    db.configure_mappers()  # very important!
 
-    Article.query.search(u'Finland').limit(5).all()
+    with app.app_context():
+        db.create_all()
 
-Note that if you are still using Python 2 you will need to replace the String and Text datatypes with Unicode and UnicodeText, respectively.
+The ``SearchQueryMixin`` provides a ``search`` method to ``ArticleQuery``. You
+can chain calls just like when using query filter calls. Here we search for
+first five articles that contain the word "Finland"::
+
+    Article.query.search("Finland").limit(5).all()


### PR DESCRIPTION
- Fix some grammar and formatting issues
- Add a warning that the query interface is considered legacy in SQLAlchemy. Use more neutral language not to encourage using the `SearchQueryMixin` class anymore.
- Ensure the code examples work.
- Remove the note about Python 2 since we don't support it anymore.