### PR TITLE
refactor: migrate from legacy query API to select()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Unreleased
   the tests were only run on PostgreSQL 12.
 - Rewrite the documentation to be up-to-date with the codebase, to fix the
   grammar and formatting issues, and to ensure the code examples are correct.
+- The query interface is considered legacy in SQLAlchemy 2.0. Migrate the tests
+  and documentation to use ``Session.execute()`` in conjunction with ``select()`` to
+  run ORM queries.
 
 1.4.1 (2021-06-15)
 ^^^^^^^^^^^^^^^^^^

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -83,12 +83,12 @@ After we've created the articles and populated the database, we can now perform
 full-text searches on them using the :func:`~sqlalchemy_searchable.search`
 function::
 
+    from sqlalchemy import select
     from sqlalchemy_searchable import search
 
-    query = session.query(Article)
-    query = search(query, "first")
-
-    print(query.first().name)
+    query = search(select(Article), "first")
+    article = session.scalars(query).first()
+    print(article.name)
     # Output: First article
 
 API

--- a/tests/test_multiple_vectors_per_class.py
+++ b/tests/test_multiple_vectors_per_class.py
@@ -61,9 +61,8 @@ class TestMultipleSearchVectorsSearchFunction:
         session.add(TextMultiItem(name="ipsum", content="admin content"))
         session.commit()
 
-        query = session.query(TextMultiItem)
-        s1 = search(query, "ipsum", vector=TextMultiItem.name_vector)
-        assert s1.first().name == "ipsum"
+        s1 = search(sa.select(TextMultiItem), "ipsum", vector=TextMultiItem.name_vector)
+        assert session.scalars(s1).first().name == "ipsum"
 
     def test_without_auto_index(self, TextMultiItem):
         indexes = TextMultiItem.__table__.indexes

--- a/tests/test_searchable.py
+++ b/tests/test_searchable.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy import func, select
 from sqlalchemy.orm.query import Query
 
 from sqlalchemy_searchable import search, SearchQueryMixin
@@ -70,8 +71,8 @@ class TestSearchQueryMixin:
         assert query.count() == 2
 
     def test_search_specific_columns(self, TextItem, session):
-        query = search(session.query(TextItem.id), "admin")
-        assert query.count() == 1
+        query = search(select(TextItem.id), "admin").subquery()
+        assert session.scalar(select(func.count()).select_from(query)) == 1
 
     def test_sorted_search_results(self, TextItem, session, items):
         query = TextItemQuery(TextItem, session)
@@ -98,8 +99,8 @@ class TestUsesGlobalConfigOptionsAsFallbacks:
         session.commit()
 
     def test_uses_global_regconfig_as_fallback(self, session, TextItem):
-        query = search(session.query(TextItem.id), "the")
-        assert query.count() == 1
+        query = search(select(TextItem.id), "the").subquery()
+        assert session.scalar(select(func.count()).select_from(query)) == 1
 
 
 class TestSearchableInheritance:

--- a/tests/test_weighted_search_vector.py
+++ b/tests/test_weighted_search_vector.py
@@ -61,7 +61,8 @@ class TestWeightedSearchFunction:
         session.commit()
 
     def test_weighted_search_results(self, session, WeightedTextItem):
-        query = session.query(WeightedTextItem)
-        first, second = search(query, "klaatu", sort=True).all()
+        first, second = session.scalars(
+            search(sa.select(WeightedTextItem), "klaatu", sort=True)
+        ).all()
         assert first.search_vector == "'barada':2B 'klaatu':1A 'nikto':3B"
         assert second.search_vector == "'barada':3B 'gort':1A 'klaatu':2B 'nikto':4B"


### PR DESCRIPTION
The query interface is legacy in SQLAlchemy 2.0. Migrate the tests and documentation to use the `Session.execute()` in conjunction with `select()` to run ORM queries. The documentation and tests regarding `SearchQueryMixin` continue using the legacy query API.